### PR TITLE
Refine benchmark script logic

### DIFF
--- a/calibration_boards/objdetect_benchmark.py
+++ b/calibration_boards/objdetect_benchmark.py
@@ -53,10 +53,10 @@ def get_norm(gold_corners, corners, type_dist):
 
 
 def get_max_error(accuracy_threshold, type_dist):
-    if type_dist is TypeNorm.l1 or TypeNorm.l2 or TypeNorm.l3 or TypeNorm.l_inf:
-        return accuracy_threshold
+    if type_dist in (TypeNorm.l1, TypeNorm.l2, TypeNorm.l_inf):
+        return accuracy_threshold 
     if type_dist is TypeNorm.intersection_over_union:
-        return 1
+        return 1.0
     raise TypeError("this TypeNorm isn't supported")
 
 
@@ -77,15 +77,15 @@ def get_synthetic_rt(yaw, pitch, distance):
 def get_coord(num_rows, num_cols, start_x=0, start_y=0):
     i, j = np.ogrid[:num_rows, :num_cols]
     v = np.empty((num_rows, num_cols, 2), dtype=np.float32)
-    v[..., 0] = j + start_y
-    v[..., 1] = i + start_x
+    v[..., 0] = j + start_x
+    v[..., 1] = i + start_y
     v.shape = (1, -1, 2)
     return v
 
 
 class TransformObject:
     def __init__(self):
-        self.name = "none"
+        self.name = ""
 
     def transform_image(self, image):
         return image
@@ -825,7 +825,7 @@ def main():
     parser.add_argument("--board_y", help="input board y size", default="6", action="store", dest="board_y", type=int)
     parser.add_argument("--rel_center_x", help="the relative x-axis location of the center of the board in the image",
                         default=".5", action="store", dest="rel_center_x", type=float)
-    parser.add_argument("--rel_center_y", help="the relative x-axis location of the center of the board in the image",
+    parser.add_argument("--rel_center_y", help="the relative y-axis location of the center of the board in the image",
                         default=".5", action="store", dest="rel_center_y", type=float)
     parser.add_argument("--metric", help="Metric for distance between result and gold", default="l_inf", action="store",
                         dest="metric", choices=['l1', 'l2', 'l_inf', 'intersection_over_union'], type=str)
@@ -886,12 +886,12 @@ def main():
 
     folder_name = "report_" + get_time()
     configuration = args.configuration
-    if configuration == "generate" or configuration == "generate_run":
+    if configuration in ("generate", "generate_run"):
         generate_dataset(args, synthetic_object)
-        if configuration == "generate":
-            return
+        return
     elif configuration == "show":
-        distances1 = read_distances(dataset_path+'/'+args.d1)
+        file = args.d1 if args.d1.endswith('.json') else args.d1 + '.json'
+        distances1 = read_distances(os.path.join(dataset_path, file))
         distances3 = distances1
         if args.d2 != '':
             distances2 = read_distances(dataset_path + '/' + args.d2)

--- a/calibration_boards/objdetect_benchmark.py
+++ b/calibration_boards/objdetect_benchmark.py
@@ -45,8 +45,17 @@ TypeNorm = Enum('TypeNorm', 'l1 l2 l_inf intersection_over_union')
 def get_norm(gold_corners, corners, type_dist):
     if type_dist is TypeNorm.l1:
         return LA.norm((gold_corners - corners).flatten(), ord=1)
-    if type_dist is TypeNorm.l2 or type_dist is TypeNorm.intersection_over_union:
+    if type_dist is TypeNorm.l2:
         return LA.norm((gold_corners - corners).flatten(), ord=2)
+    if type_dist is TypeNorm.intersection_over_union:
+        poly1 = gold_corners.astype(np.float32)
+        poly2 = corners.astype(np.float32)
+        ret, inter_poly = cv.intersectConvexConvex(poly1, poly2)
+        area_inter = ret if isinstance(ret, float) else cv.contourArea(inter_poly)
+        area1 = cv.contourArea(poly1)
+        area2 = cv.contourArea(poly2)
+        union = area1 + area2 - area_inter
+        return (area_inter / union) if union > 0 else 0.0
     if type_dist is TypeNorm.l_inf:
         return LA.norm((gold_corners - corners).flatten(), ord=np.inf)
     raise TypeError("this TypeNorm isn't supported")
@@ -73,14 +82,6 @@ def get_synthetic_rt(yaw, pitch, distance):
     tvec = np.array([[0], [0], [distance]])
     return rvec, tvec
 
-
-def get_coord(num_rows, num_cols, start_x=0, start_y=0):
-    i, j = np.ogrid[:num_rows, :num_cols]
-    v = np.empty((num_rows, num_cols, 2), dtype=np.float32)
-    v[..., 0] = j + start_x
-    v[..., 1] = i + start_y
-    v.shape = (1, -1, 2)
-    return v
 
 
 class TransformObject:
@@ -124,6 +125,7 @@ class PerspectiveTransform(TransformObject):
         obj_points[:, -1:] = 0.
 
         corners, _ = cv.projectPoints(obj_points, rvec, tvec, camera_matrix, np.zeros((5, 1), dtype=np.float64))
+        corners = corners.reshape(-1, 2).astype(np.float32)
         self.transformation = cv.getPerspectiveTransform(original_corners, corners)
 
     def transform_image(self, image):
@@ -888,7 +890,8 @@ def main():
     configuration = args.configuration
     if configuration in ("generate", "generate_run"):
         generate_dataset(args, synthetic_object)
-        return
+        if configuration == "generate":
+            return
     elif configuration == "show":
         file = args.d1 if args.d1.endswith('.json') else args.d1 + '.json'
         distances1 = read_distances(os.path.join(dataset_path, file))


### PR DESCRIPTION
**Refine benchmark script logic**

* Correct `get_max_error` boolean logic and remove nonexistent `l3` branch
* Remove the now‑unused`get_coord`function
* Default `TransformObject.name` to empty string to avoid “none” history entries
* Update help text for `--rel_center_y`
* **Implement true Intersection‑over‑Union** in `get_norm` using `cv.intersectConvexConvex` and `cv.contourArea`
* **Reshape and cast** projected `corners` in `PerspectiveTransform` to `float32` before calling `getPerspectiveTransform`


## Tests

<details><summary><code>tests/test_utils.py</code></summary>

```python
import numpy as np
import pytest

from objdetect_benchmark import get_norm, get_max_error, TypeNorm

def test_get_norm_l1():
    a = np.array([[0, 0], [1, 1]], float)
    b = np.array([[1, 1], [2, 2]], float)
    # |(1,1)-(0,0)|₁ + |(2,2)-(1,1)|₁ = (1+1) + (1+1) = 4
    assert get_norm(a, b, TypeNorm.l1) == pytest.approx(4)

def test_get_norm_l2():
    a = np.array([[0, 0], [0, 0]], float)
    b = np.array([[3, 4], [0, 0]], float)
    # flatten difference = [3,4,0,0], L₂ = sqrt(3²+4²) = 5
    assert get_norm(a, b, TypeNorm.l2) == pytest.approx(5)

def test_get_norm_linf():
    a = np.array([[0, 0], [1, 5]], float)
    b = np.array([[2, 1], [0, 0]], float)
    # per-point diffs: [(2,1),(1,5)] → flattened [2,1,1,5], max = 5
    assert get_norm(a, b, TypeNorm.l_inf) == pytest.approx(5)

def test_get_norm_iou_full_overlap():
    # identical quads → IoU = 1.0
    quad = np.array([[0,0], [1,0], [1,1], [0,1]], float)
    assert get_norm(quad, quad, TypeNorm.intersection_over_union) == pytest.approx(1.0)

def test_get_norm_iou_partial_overlap():
    # gold: unit square; detected: shifted right by 0.5
    gold = np.array([[0,0], [1,0], [1,1], [0,1]], float)
    det  = np.array([[0.5,0], [1.5,0], [1.5,1], [0.5,1]], float)
    # overlap area = 0.5×1 = 0.5; union = 1 + 1 - 0.5 = 1.5 → IoU = 1/3
    assert get_norm(gold, det, TypeNorm.intersection_over_union) == pytest.approx(1/3)

def test_get_max_error():
    assert get_max_error(5, TypeNorm.l2) == 5
    assert get_max_error(0.1, TypeNorm.intersection_over_union) == 1.0

```

</details>

<details><summary><code>tests/test_generate_run.py</code></summary>

```python
import os
import pytest
from objdetect_benchmark import main

def test_gen_and_show(tmp_path, monkeypatch):
    monkeypatch.chdir(tmp_path)

    import sys
    sys.argv[:] = [
        "objdetect_benchmark.py",
        "--configuration", "generate",
        "-p", str(tmp_path/"out"),
        "--synthetic_object", "chessboard",
        "--cell_img_size", "50",
        "--board_x", "3", "--board_y", "3"
    ]

    main()

    output_files = list((tmp_path/"out").rglob("*.json"))
    assert output_files, "expected some JSON"

```

</details>

---

To run locally:

```bash
cd /opencv_benchmarks/calibration_boards
source .venv/bin/activate
export PYTHONPATH=$PWD
pytest -q
```
